### PR TITLE
Fixed source link - minor hotfix

### DIFF
--- a/1BDFDB.plugin.js
+++ b/1BDFDB.plugin.js
@@ -4,7 +4,7 @@
  * @authorId 347419615007080453
  * @version 3.0.7
  * @description Required Library for ShowHiddenChannels plugin
- * @source https://raw.githubusercontent.com/JustOptimize/return-ShowHiddenChannels/With-Library/
+ * @source https://github.com/JustOptimize/return-ShowHiddenChannels/
  * @updateUrl https://raw.githubusercontent.com/JustOptimize/return-ShowHiddenChannels/With-Library/1BDFDB.plugin.js
  */
 

--- a/ShowHiddenChannels.plugin.js
+++ b/ShowHiddenChannels.plugin.js
@@ -4,7 +4,7 @@
  * @authorId 347419615007080453
  * @version 4.0.2
  * @description Displays all hidden Channels, which can't be accessed due to Role Restrictions, this won't allow you to read them (impossible)
- * @source https://raw.githubusercontent.com/JustOptimize/return-ShowHiddenChannels/With-Library/
+ * @source https://github.com/JustOptimize/return-ShowHiddenChannels/
  * @updateUrl https://raw.githubusercontent.com/JustOptimize/return-ShowHiddenChannels/With-Library/ShowHiddenChannels.plugin.js
  */
 


### PR DESCRIPTION
The original source link goes to a malformed GitHub raw file link. Nothing major, but may be worth including with later updates since the current source gives HTTP Error 400.

The GitHub embedded editor also removed whitespace at the end of one of the committed files, but both plugins still operate normally.