### PR TITLE
Force the date to be displayed correctly

### DIFF
--- a/ShowHiddenChannels.plugin.js
+++ b/ShowHiddenChannels.plugin.js
@@ -175,6 +175,7 @@ module.exports = (() => {
         React,
         ReactDOM,
         Tooltip,
+        LocaleManager
       }
     } = Library;
 
@@ -762,7 +763,7 @@ module.exports = (() => {
           const excerpt = binary.substring(0, 42);
           const decimal = parseInt(excerpt, 2);
           const unix = decimal + 1420070400000;
-          return new Date(unix).toLocaleString();
+          return new Date(unix).toLocaleString(LocaleManager._chosenLocale);
         } catch (err) {
           Logger.err(err);
           return "(Failed to get date)";


### PR DESCRIPTION
For some reason, "en-US" is always set as the first value within `navigator.languages`.

This issue usually isn't noticed due to the fact that discord stores the set language somewhere else, however `Date().toLocaleString()` does use this incorrect variable and thus always displays dates in the "en-US" locale.

This can be fixed by specifying the correct locale stored within the `LocaleManager` module